### PR TITLE
fix: Support relative paths in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Removing this file can potentially cause unwanted changes to the project if the 
         settings:
           - name: project_dir
             kind: string
-            value: ${MELTANO_PROJECT_ROOT}/transform/
+            value: transform
           - name: profiles_dir
             kind: string
-            value: ${MELTANO_PROJECT_ROOT}/transform/profiles/bigquery/
+            value: transform/profiles
           - name: file_path
             kind: string
-            value: ${MELTANO_PROJECT_ROOT}/utilities/elementary/report.html
+            value: output/elementary_report.html
           - name: skip_pre_invoke
             env: ELEMENTARY_EXT_SKIP_PRE_INVOKE
             kind: boolean
@@ -87,10 +87,10 @@ Removing this file can potentially cause unwanted changes to the project if the 
             send-report --slack-token ${ELEMENTARY_SLACK_TOKEN} --slack-channel-name ${ELEMENTARY_SLACK_CHANNEL_NAME}
 
         config:
-          profiles-dir: ${MELTANO_PROJECT_ROOT}/transform/profiles/bigquery/
-          file-path: ${MELTANO_PROJECT_ROOT}/utilities/elementary/report.html
+          profiles-dir: transform/profiles/bigquery
+          file-path: output/my-elementary-report.html
           slack-channel-name: my-channel-name
-          google-service-account-path: ${MELTANO_PROJECT_ROOT}/.secrets/elementary-gcs.json
+          google-service-account-path: .secrets/elementary-gcs.json
           gcs-bucket-name: my-storage-device
           skip_pre_invoke: true
           env: prod

--- a/elementary_ext/extension.py
+++ b/elementary_ext/extension.py
@@ -34,7 +34,7 @@ class elementary(ExtensionBase):
         )
         self.config_dir_path = os.getenv("ELEMENTARY_CONFIG_DIR_PATH", None)
         self.dbt_ext_type = os.getenv("DBT_EXT_TYPE", "bigquery")
-        self.file_path = Path(os.getenv("ELEMENTARY_FILE_PATH", "utilities/elementary/report.html"))
+        self.file_path = Path(os.getenv("ELEMENTARY_FILE_PATH", "output/elementary_report.html"))
         self.slack_channel_name = os.getenv("ELEMENTARY_SLACK_CHANNEL_NAME", "")
         self.slack_token = os.getenv("ELEMENTARY_SLACK_TOKEN", "")
         self.days_back= os.getenv("ELEMENTARY_DAYS_BACK", None)

--- a/elementary_ext/extension.py
+++ b/elementary_ext/extension.py
@@ -35,7 +35,6 @@ class elementary(ExtensionBase):
         self.config_dir_path = os.getenv("ELEMENTARY_CONFIG_DIR_PATH", None)
         self.dbt_ext_type = os.getenv("DBT_EXT_TYPE", "bigquery")
         self.file_path = Path(os.getenv("ELEMENTARY_FILE_PATH", "utilities/elementary/report.html"))
-
         self.slack_channel_name = os.getenv("ELEMENTARY_SLACK_CHANNEL_NAME", "")
         self.slack_token = os.getenv("ELEMENTARY_SLACK_TOKEN", "")
         self.days_back= os.getenv("ELEMENTARY_DAYS_BACK", None)
@@ -44,13 +43,6 @@ class elementary(ExtensionBase):
         self.disable_samples= os.getenv("ELEMENTARY_DISABLE_SAMPLES", None)
         self.environment= os.getenv("ELEMENTARY_ENV", None)
         self.full_refresh_dbt_models= os.getenv("ELEMENTARY_FULL_REFRESH_DBT_MODELS", None)
-
-        
-
-        self.dbt_profiles_dir = Path(
-            os.getenv("ELEMENTARY_PROFILES_DIR", self.dbt_project_dir / "profiles")
-        )
-
         self.skip_pre_invoke = (
             os.getenv("ELEMENTARY_EXT_SKIP_PRE_INVOKE", "false").lower() == "true"
         )

--- a/elementary_ext/extension.py
+++ b/elementary_ext/extension.py
@@ -46,9 +46,7 @@ class elementary(ExtensionBase):
         self.skip_pre_invoke = (
             os.getenv("ELEMENTARY_EXT_SKIP_PRE_INVOKE", "false").lower() == "true"
         )
-        self.elementary_invoker = Invoker(self.elementary_bin, cwd=self.dbt_profiles_dir)
-
-
+        self.elementary_invoker = Invoker(self.elementary_bin)
 
     def pre_invoke(self, invoke_name: str | None, *invoke_args: Any) -> None:
         """Pre-invoke hook.


### PR DESCRIPTION
Prior to this change, relative paths in config did not work as the dbt profiles directory was set as the working directory when invoking the `edr` executable. I'm not sure why this is the case, since `--profiles-dir` seems to passed anyway (unless a config directory path is set, but I don't know enough about this to say for sure)... As the README indicates, you can work around this issue by providing absolute paths (implicitly) using `MELTANO_PROJECT_ROOT`.

### Changes
- Support relative file paths by removing the defined working directory (default when running with Meltano is the project root) - this removes the dependency on using `MELTANO_PROJECT_ROOT` for default values of settings in its [Hub definition](https://github.com/meltano/hub/blob/main/_data/meltano/utilities/elementary/elementary.yml) and when providing an alternate profiles directory or file path as config (see [`Configuration` in updated README](https://github.com/Matatika/elementary-ext/blob/7f113b50526fdab9190c95d854491757a5695db1/README.md#configuration))
- Better report default file path for a Meltano project: `output/elementary_report.html` - the directory structure of the previous default `utilities/elementary/report.html` is not bundled with a new Meltano project; `output` is
- Small code duplication fix